### PR TITLE
Adding account security lock/unlock ✅

### DIFF
--- a/web-auth/alembic/seeder/privileges.json
+++ b/web-auth/alembic/seeder/privileges.json
@@ -1,0 +1,51 @@
+[
+    {
+        "_id": 1, 
+        "service": "upload_oct",
+        "access": true,
+        "read": true,
+        "write": true
+    },
+    {
+        "_id": 2, 
+        "service": "diagnosis_dashboard",
+        "access": true,
+        "read": true,
+        "write": false
+    },
+    {
+        "_id": 3, 
+        "service": "api_doc",
+        "access": true,
+        "read": true,
+        "write": false
+    },
+    {
+        "_id": 4, 
+        "service": "generate_key",
+        "access": true,
+        "read": true,
+        "write": true
+    },
+    {
+        "_id": 5, 
+        "service": "list_diagnosis",
+        "access": true,
+        "read": true,
+        "write": false
+    },
+    {
+        "_id": 6, 
+        "service": "search_diagnosis",
+        "access": true,
+        "read": true,
+        "write": true
+    },
+    {
+        "_id": 7, 
+        "service": "specific_diagnose_report",
+        "access": true,
+        "read": true,
+        "write": false
+    }
+]

--- a/web-auth/alembic/seeder/role-privileges.json
+++ b/web-auth/alembic/seeder/role-privileges.json
@@ -1,0 +1,14 @@
+[
+    {"role": 1, "privilege":1},
+    {"role": 1, "privilege":2},
+    {"role": 1, "privilege":5},
+    {"role": 1, "privilege":6},
+    {"role": 1, "privilege":7},
+
+    {"role": 2, "privilege":3},
+    {"role": 2, "privilege":4},
+
+
+    {"role": 3, "privilege":6},
+    {"role": 3, "privilege":7}
+]

--- a/web-auth/alembic/seeder/roles.json
+++ b/web-auth/alembic/seeder/roles.json
@@ -1,7 +1,7 @@
 [
-    {"role": "medical-practitionar"},
-    {"role": "medical-IT"},
-    {"role": "patient"},
-    {"role": "admin"},
-    {"role": "moderator"}
+    {"_id": 1, "role": "medical-practitionar"},
+    {"_id": 2, "role": "medical-IT"},
+    {"_id": 3, "role": "patient"},
+    {"_id": 4, "role": "admin"},
+    {"_id": 5, "role": "moderator"}
 ]

--- a/web-auth/alembic/versions/131421949404_role_privilage_relationship.py
+++ b/web-auth/alembic/versions/131421949404_role_privilage_relationship.py
@@ -1,0 +1,68 @@
+"""role-privilage-relationship
+
+Revision ID: 131421949404
+Revises: 6d5b3262f9bd
+Create Date: 2025-02-10 10:34:04.600231
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+import os
+import json
+from dotenv import load_dotenv
+load_dotenv()
+
+
+# revision identifiers, used by Alembic.
+revision: str = '131421949404'
+down_revision: Union[str, None] = '6d5b3262f9bd'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'ROLE_PRIVILEGES',
+        sa.Column(name='role', type_=sa.Integer(), nullable=False, primary_key=True),
+        sa.Column(name='privilege', type_=sa.Integer(), nullable=False, primary_key=True)
+    )
+    # ROLE <-> ROLE_PRIVILEGES
+    op.create_foreign_key(
+        constraint_name=None,
+        source_table='ROLE_PRIVILEGES',
+        referent_table='ROLE',
+        local_cols=['role'],
+        remote_cols=['_id'],
+        ondelete='CASCADE',
+        onupdate='CASCADE'
+    )
+
+    # PRIVILEGES <-> ROLE_PRIVILEGES
+    op.create_foreign_key(
+        constraint_name=None,
+        source_table='ROLE_PRIVILEGES',
+        referent_table='PRIVILEGES',
+        local_cols=['privilege'],
+        remote_cols=['_id'],
+        ondelete='CASCADE',
+        onupdate='CASCADE'
+    )
+
+    cols:list[sa.Column]=[
+        sa.Column(name='role', type_=sa.Integer(), nullable=False, primary_key=True),
+        sa.Column(name='privilege', type_=sa.Integer(), nullable=False, primary_key=True)
+    ]
+
+    if os.getenv('ENV').lower() == 'development':
+        with open('alembic/seeder/role-privileges.json', 'r') as seed:
+            seeder=json.load(seed)
+        roles=sa.Table('ROLE_PRIVILEGES', sa.MetaData(),*cols)
+        op.bulk_insert(table=roles, rows=seeder)
+
+
+def downgrade() -> None:
+    op.drop_table('ROLE_PRIVILEGES')

--- a/web-auth/alembic/versions/f72d4fce3e74_privileges_migration.py
+++ b/web-auth/alembic/versions/f72d4fce3e74_privileges_migration.py
@@ -11,6 +11,11 @@ from alembic import op
 import sqlalchemy as sa
 
 
+import os
+import json
+from dotenv import load_dotenv
+load_dotenv()
+
 # revision identifiers, used by Alembic.
 revision: str = 'f72d4fce3e74'
 down_revision: Union[str, None] = '391ad3a0685e'
@@ -26,18 +31,21 @@ def upgrade() -> None:
         sa.Column(name='access', type_=sa.Boolean(), default=False, nullable=False),
         sa.Column(name='read', type_=sa.Boolean(), default=False, nullable=False),
         sa.Column(name='write', type_=sa.Boolean(), default=False, nullable=False),
-        sa.Column(name='role', type_=sa.Integer(), nullable=False)
     )
 
-    op.create_foreign_key(
-        constraint_name=None,
-        source_table='PRIVILEGES',
-        referent_table='ROLE',
-        local_cols=['role'],
-        remote_cols=['_id'],
-        ondelete='CASCADE',
-        onupdate='CASCADE'
-    )
+    cols:list[sa.Column]=[
+        sa.Column(name='_id', type_=sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(name='service', type_=sa.String(35), nullable=False),
+        sa.Column(name='access', type_=sa.Boolean(), default=False, nullable=False),
+        sa.Column(name='read', type_=sa.Boolean(), default=False, nullable=False),
+        sa.Column(name='write', type_=sa.Boolean(), default=False, nullable=False),
+    ]
+
+    if os.getenv('ENV').lower() == 'development':
+        with open('alembic/seeder/privileges.json', 'r') as seed:
+            seeder=json.load(seed)
+        roles=sa.Table('PRIVILEGES', sa.MetaData(),*cols)
+        op.bulk_insert(table=roles, rows=seeder)
 
 
 def downgrade() -> None:

--- a/web-auth/controllers/__init__.py
+++ b/web-auth/controllers/__init__.py
@@ -1,1 +1,2 @@
 from .user_controller import UserController
+from .security_controller import SecurityController

--- a/web-auth/controllers/security_controller.py
+++ b/web-auth/controllers/security_controller.py
@@ -1,0 +1,88 @@
+from sqlalchemy.ext.asyncio  import AsyncSession
+from sqlalchemy.engine import Result
+from sqlalchemy.future import select
+
+from models import UserModel
+
+from views import (
+    LockRequest,
+    LockBaseResponse,
+    Lock200,
+    Lock400,
+    Lock404,
+    Lock409,
+    Lock500,
+    #--Unlock--#
+    UnLockRequest,
+    UnLockBaseResponse,
+    UnLock200,
+    UnLock400,
+    UnLock404,
+    UnLock409,
+    UnLock500
+)
+
+class SecurityController:
+    @staticmethod
+    async def lock_account(
+        inf:LockRequest,
+        session:AsyncSession | None
+    ) -> LockBaseResponse:
+        try:
+            if not session: raise Exception('Session is not initialized')
+            # if email is not provided assign account_id else email is assignd
+            _identifier= inf.account_id if not inf.email else inf.email
+            
+            # if both are missing return bad request
+            if not _identifier: return Lock400()
+            
+            #make the right query
+            _select=select(UserModel).where(UserModel.email == _identifier if inf.email else UserModel._id == _identifier)
+            _res:Result= await session.execute(_select)
+            _usr:UserModel= _res.scalar_one_or_none()
+            
+            # User is not exist
+            if _usr is None: return Lock404()
+
+            # User account already locked
+            if _usr.locked: return Lock409()
+
+            _usr.locked=True
+            await session.commit()
+            return Lock200()
+        except Exception as e:
+            print(e)
+            return Lock500()
+    
+    @staticmethod
+    async def unlock(
+        inf:UnLockRequest,
+        session:AsyncSession | None
+    )->UnLockBaseResponse:
+        try:
+            if not session: raise Exception('Session is not initialized')
+            # if email is not provided assign account_id else email is assignd
+            _identifier= inf.account_id if not inf.email else inf.email
+            
+            # if both are missing return bad request
+            if not _identifier: return UnLock400()
+
+            _select=select(UserModel).where(UserModel.email == _identifier if inf.email else UserModel._id == _identifier)
+            _res:Result= await session.execute(_select)
+            _usr:UserModel= _res.scalar_one_or_none()
+
+            # User is not exist
+            if _usr is None: return UnLock404()
+
+
+            # User account already unlocked
+            if not _usr.locked: return UnLock409()
+
+            _usr.locked=False
+            _usr.locked_at=None
+            await session.commit()
+            return UnLock200()
+        except Exception as e:
+            print(e)
+            return UnLock500()
+        

--- a/web-auth/controllers/user_controller.py
+++ b/web-auth/controllers/user_controller.py
@@ -16,6 +16,7 @@ from views import (
     #--Login Views--#
     LoginResponseBase,
     Login200,
+    Login403,
     Login404,
     Login500,
     LoginRequest
@@ -73,6 +74,8 @@ class UserController:
             # user is not exist
             if _usr is None: return Login404()
             
+            # if account is locked return early
+            if _usr.locked: return Login403()
 
             # compare credentials
             if not HashHelper.compare(

--- a/web-auth/main.py
+++ b/web-auth/main.py
@@ -11,6 +11,7 @@ service = FastAPI(
 def ping(): 
     return JSONResponse(content={'message': 'pong', 'health': 'Running', 'code': 200}, status_code=200)
 
-from routes import authentication
+from routes import authentication, security
 
 service.include_router(router=authentication)
+service.include_router(router=security)

--- a/web-auth/models/privilege_model.py
+++ b/web-auth/models/privilege_model.py
@@ -1,11 +1,11 @@
 from .base_model import BaseModel
-from sqlalchemy import Column, Integer, String, Boolean, ForeignKey
+from sqlalchemy import Integer, String, Boolean
+from sqlalchemy.orm import mapped_column, Mapped
 
 class PrivilegeModel(BaseModel):
     __tablename__='PRIVILEGES'
-    _id=Column(Integer, primary_key=True, autoincrement=True)
-    service=Column(String(35), nullable=False)
-    access=Column(Boolean, nullable=False, default=False)
-    read=Column(Boolean, nullable=False, default=False)
-    write=Column(Boolean, nullable=False, default=False)
-    role=Column(Integer, ForeignKey('ROLE._id', ondelete='CASCADE', onupdate='CASCADE'), nullable=False)
+    _id:Mapped[int]=mapped_column(Integer, primary_key=True, autoincrement=True)
+    service:Mapped[str]=mapped_column(String(35), nullable=False)
+    access:Mapped[bool]=mapped_column(Boolean, nullable=False, default=False)
+    read:Mapped[bool]=mapped_column(Boolean, nullable=False, default=False)
+    write:Mapped[bool]=mapped_column(Boolean, nullable=False, default=False)

--- a/web-auth/models/role_model.py
+++ b/web-auth/models/role_model.py
@@ -1,7 +1,9 @@
 from .base_model import BaseModel
-from sqlalchemy import Column, Integer, String
+from sqlalchemy import Integer, String
+from sqlalchemy.orm import mapped_column, Mapped
+
 
 class RoleModel(BaseModel):
     __tablename__='ROLE'
-    _id=Column(Integer, primary_key=True, autoincrement=True)
-    role=Column(String(35), nullable=False, unique=True)
+    _id:Mapped[int]=mapped_column(Integer, primary_key=True, autoincrement=True)
+    role:Mapped[str]=mapped_column(String(35), nullable=False, unique=True)

--- a/web-auth/models/user_model.py
+++ b/web-auth/models/user_model.py
@@ -1,11 +1,16 @@
 from .base_model import BaseModel
-from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy import Integer, String, ForeignKey, Boolean, DateTime, text
+from sqlalchemy.orm import mapped_column, Mapped
 
 class UserModel(BaseModel):
     __tablename__='USER'
-    _id=Column(Integer, primary_key=True, autoincrement=True)
-    full_name=Column(String(75), nullable=False)
-    email=Column(String(150), nullable=False, unique=True)
-    password=Column(String(64), nullable=False)
-    salt=Column(String(128), nullable=False)
-    role=Column(Integer, ForeignKey('ROLE._id', ondelete='SET NULL', onupdate='CASCADE'), nullable=True)
+    
+    _id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    full_name: Mapped[str] = mapped_column(String(75), nullable=False)
+    email: Mapped[str] = mapped_column(String(150), nullable=False, unique=True)
+    password: Mapped[str] = mapped_column(String(64), nullable=False)
+    salt: Mapped[str] = mapped_column(String(128), nullable=False)
+    role: Mapped[int | None] = mapped_column(Integer, ForeignKey('ROLE._id', ondelete='SET NULL', onupdate='CASCADE'), nullable=True)
+    locked: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    locked_at: Mapped[DateTime | None] = mapped_column(DateTime, nullable=True)
+    created_at: Mapped[DateTime] = mapped_column(DateTime, nullable=False, server_default=text("timezone('Asia/Riyadh', now())"))

--- a/web-auth/routes/__init__.py
+++ b/web-auth/routes/__init__.py
@@ -1,1 +1,2 @@
 from .authentication import authentication
+from .security import security

--- a/web-auth/routes/security.py
+++ b/web-auth/routes/security.py
@@ -1,0 +1,60 @@
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+
+security:APIRouter=APIRouter(
+    prefix='/security-measure',
+    tags=['Security Measures']
+)
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from core import GET_ENGINE
+
+
+from controllers import SecurityController
+
+from views import (
+    LockRequest,
+    LockBaseResponse,
+    Lock200,
+    lock_dump
+)
+
+@security.put(
+    path='/lock',
+    description='Security measure to lock account due suspicious activity or rate-limiting.',
+    status_code=200,
+    response_model=Lock200,
+    responses=lock_dump
+)
+async def lock_endpoint(
+    req:LockRequest,
+    session:AsyncSession | None=Depends(GET_ENGINE)
+):
+    response:LockBaseResponse=await SecurityController.lock_account(inf=req, session=session)
+    if not isinstance(response, Lock200):
+        return JSONResponse(status_code=response.code, content=response.model_dump())
+    return response
+
+
+from views import (
+    UnLockRequest,
+    UnLockBaseResponse,
+    UnLock200,
+    unlock_dump
+)
+
+@security.put(
+    path='/unlock',
+    description='Security measure to unlock account after verifing the real user',
+    status_code=200,
+    response_model=UnLock200,
+    responses=unlock_dump
+)
+async def unlock_endpoint(
+    req:UnLockRequest,
+    session:AsyncSession | None=Depends(GET_ENGINE)
+):
+    res:UnLockBaseResponse=await SecurityController.unlock(inf=req, session=session)
+    if not isinstance(res, UnLock200):
+        return JSONResponse(status_code=res.code, content=res.model_dump())
+    return res

--- a/web-auth/views/__init__.py
+++ b/web-auth/views/__init__.py
@@ -1,2 +1,4 @@
 from .register import *
 from .login import *
+from .lock import *
+from .unlock import *

--- a/web-auth/views/lock/__init__.py
+++ b/web-auth/views/lock/__init__.py
@@ -1,0 +1,6 @@
+from .request import LockRequest
+from .base_response import LockBaseResponse
+from .response_20x import *
+from .response_40x import *
+from .response_50x import *
+from .response_dump import lock_dump

--- a/web-auth/views/lock/base_response.py
+++ b/web-auth/views/lock/base_response.py
@@ -1,0 +1,15 @@
+from pydantic import Field, BaseModel
+
+class LockBaseResponse(BaseModel):
+    code:int=Field(
+        ...,
+        title='Response Status Code',
+        description='Protocol status code associated with response',
+        strict=True
+    )
+    message:str=Field(
+        ...,
+        title='Response Message',
+        description='Illustration meesage for the response state.',
+        strict=True
+    )

--- a/web-auth/views/lock/request.py
+++ b/web-auth/views/lock/request.py
@@ -1,0 +1,24 @@
+from pydantic import Field, EmailStr, BaseModel, model_validator
+
+class LockRequest(BaseModel):
+    email:EmailStr=Field(
+        None,
+        title='User email',
+        description='Registered user email',
+        examples=['email@example.com'],
+        strict=True
+    )
+    account_id:int=Field(
+        None,
+        title='Account Identifier',
+        description='Identifier generated when user registered and it used to identify user',
+        examples=['12135', '22351'],
+        strict=True
+    )
+
+    @model_validator(mode='before')
+    def at_least_one(cls, values):
+        email, account_id=values.get('email'), values.get('account_id')
+        if not email and not account_id:
+            raise ValueError("Either 'email' or 'account_id' must be provided.")
+        return values

--- a/web-auth/views/lock/response_20x.py
+++ b/web-auth/views/lock/response_20x.py
@@ -1,0 +1,19 @@
+from pydantic import Field
+from .base_response import LockBaseResponse
+
+class Lock20X(LockBaseResponse):
+    pass
+
+class Lock200(Lock20X):
+    code:int=Field(
+        200,
+        title='Response Status Code',
+        description='Protocol status code associated with response',
+        strict=True
+    )
+    message:str=Field(
+        'Account Locked Successfully',
+        title='Response Message',
+        description='Illustration meesage for the response state.',
+        strict=True
+    )

--- a/web-auth/views/lock/response_40x.py
+++ b/web-auth/views/lock/response_40x.py
@@ -1,0 +1,43 @@
+from pydantic import Field
+from .base_response import LockBaseResponse
+
+class Lock40X(LockBaseResponse):
+    pass
+
+class Lock400(Lock40X):
+    code:int=Field(
+        400,
+        title='Response Status Code',
+        description='Protocol status code associated with response',
+        strict=True
+    )
+    message:str=Field(
+        'Bad Request: Provided information are invalid',
+        title='Response Message',
+        description='Illustration meesage for the response state.',
+        strict=True
+    )
+
+class Lock404(Lock40X):
+    code:int=Field(
+        404,
+        title='Response Status Code',
+        description='Protocol status code associated with response',
+    )
+    message:str=Field(
+        'User Account is Not Registered',
+        title='Response Message',
+        description='Illustration meesage for the response state.',
+    )
+
+class Lock409(Lock40X):
+    code:int=Field(
+        409,
+        title='Response Status Code',
+        description='Protocol status code associated with response',
+    )
+    message:str=Field(
+        'Conflict: User Account is Already Locked',
+        title='Response Message',
+        description='Illustration meesage for the response state.',
+    )

--- a/web-auth/views/lock/response_50x.py
+++ b/web-auth/views/lock/response_50x.py
@@ -1,0 +1,19 @@
+from pydantic import Field
+from .base_response import LockBaseResponse
+
+class Lock50X(LockBaseResponse):
+    pass
+
+class Lock500(Lock50X):
+    code:int=Field(
+        500,
+        title='Response Status Code',
+        description='Protocol status code associated with response',
+        strict=True
+    )
+    message:str=Field(
+        'Locking Account Failed Due to an Internal Error',
+        title='Response Message',
+        description='Illustration meesage for the response state.',
+        strict=True
+    )

--- a/web-auth/views/lock/response_dump.py
+++ b/web-auth/views/lock/response_dump.py
@@ -1,0 +1,36 @@
+from .response_40x import Lock400, Lock404, Lock409
+from .response_50x import Lock500
+lock_dump:dict={
+    400: {
+        'model': Lock400,
+        'content': {
+            'application/json': {
+                'example': Lock400().model_dump()
+            }
+        }
+    },
+    404: {
+        'model': Lock404,
+        'content': {
+            'application/json': {
+                'example': Lock404().model_dump()
+            }
+        }
+    },
+    409: {
+        'model': Lock409,
+        'content': {
+            'application/json': {
+                'example': Lock409().model_dump()
+            }
+        }
+    },
+    500: {
+        'model': Lock500,
+        'content': {
+            'application/json': {
+                'example': Lock500().model_dump()
+            }
+        }
+    },
+}

--- a/web-auth/views/login/__init__.py
+++ b/web-auth/views/login/__init__.py
@@ -2,5 +2,5 @@ from .request import LoginRequest
 from .base_response import LoginResponseBase
 from .response_20x import Login200
 from .response_50x import Login500
-from .response_4xx import Login404
+from .response_4xx import Login404, Login403
 from .responses_dump import login_dump

--- a/web-auth/views/login/response_4xx.py
+++ b/web-auth/views/login/response_4xx.py
@@ -15,3 +15,15 @@ class Login404(Login4XX):
         title='Response Message',
         description='Illustration meesage for the response state.',
     )
+
+class Login403(Login4XX):
+    code:int=Field(
+        403,
+        title='Response Status Code',
+        description='Protocol status code associated with response',
+    )
+    message:str=Field(
+        'Forbidden: Account is Locked',
+        title='Response Message',
+        description='Illustration meesage for the response state.',
+    )

--- a/web-auth/views/unlock/__init__.py
+++ b/web-auth/views/unlock/__init__.py
@@ -1,0 +1,6 @@
+from .request import UnLockRequest
+from .base_response import UnLockBaseResponse
+from .response_20x import *
+from .response_40x import *
+from .response_50x import *
+from .response_dump import unlock_dump

--- a/web-auth/views/unlock/base_response.py
+++ b/web-auth/views/unlock/base_response.py
@@ -1,0 +1,15 @@
+from pydantic import Field, BaseModel
+
+class UnLockBaseResponse(BaseModel):
+    code:int=Field(
+        ...,
+        title='Response Status Code',
+        description='Protocol status code associated with response',
+        strict=True
+    )
+    message:str=Field(
+        ...,
+        title='Response Message',
+        description='Illustration meesage for the response state.',
+        strict=True
+    )

--- a/web-auth/views/unlock/request.py
+++ b/web-auth/views/unlock/request.py
@@ -1,0 +1,24 @@
+from pydantic import Field, EmailStr, BaseModel, model_validator
+
+class UnLockRequest(BaseModel):
+    email:EmailStr=Field(
+        None,
+        title='User email',
+        description='Registered user email',
+        examples=['email@example.com'],
+        strict=True
+    )
+    account_id:int=Field(
+        None,
+        title='Account Identifier',
+        description='Identifier generated when user registered and it used to identify user',
+        examples=['12135', '22351'],
+        strict=True
+    )
+
+    @model_validator(mode='before')
+    def at_least_one(cls, values):
+        email, account_id=values.get('email'), values.get('account_id')
+        if not email and not account_id:
+            raise ValueError("Either 'email' or 'account_id' must be provided.")
+        return values

--- a/web-auth/views/unlock/response_20x.py
+++ b/web-auth/views/unlock/response_20x.py
@@ -1,0 +1,19 @@
+from pydantic import Field
+from .base_response import UnLockBaseResponse
+
+class UnLock20X(UnLockBaseResponse):
+    pass
+
+class UnLock200(UnLock20X):
+    code:int=Field(
+        200,
+        title='Response Status Code',
+        description='Protocol status code associated with response',
+        strict=True
+    )
+    message:str=Field(
+        'Account Unlocked Successfully',
+        title='Response Message',
+        description='Illustration meesage for the response state.',
+        strict=True
+    )

--- a/web-auth/views/unlock/response_40x.py
+++ b/web-auth/views/unlock/response_40x.py
@@ -1,0 +1,43 @@
+from pydantic import Field
+from .base_response import UnLockBaseResponse
+
+class UnLock40X(UnLockBaseResponse):
+    pass
+
+class UnLock400(UnLock40X):
+    code:int=Field(
+        400,
+        title='Response Status Code',
+        description='Protocol status code associated with response',
+        strict=True
+    )
+    message:str=Field(
+        'Bad Request: Provided information are invalid',
+        title='Response Message',
+        description='Illustration meesage for the response state.',
+        strict=True
+    )
+
+class UnLock404(UnLock40X):
+    code:int=Field(
+        404,
+        title='Response Status Code',
+        description='Protocol status code associated with response',
+    )
+    message:str=Field(
+        'User Account is Not Registered',
+        title='Response Message',
+        description='Illustration meesage for the response state.',
+    )
+
+class UnLock409(UnLock40X):
+    code:int=Field(
+        409,
+        title='Response Status Code',
+        description='Protocol status code associated with response',
+    )
+    message:str=Field(
+        'Conflict: User Account is Already Unlocked',
+        title='Response Message',
+        description='Illustration meesage for the response state.',
+    )

--- a/web-auth/views/unlock/response_50x.py
+++ b/web-auth/views/unlock/response_50x.py
@@ -1,0 +1,19 @@
+from pydantic import Field
+from .base_response import UnLockBaseResponse
+
+class UnLock50X(UnLockBaseResponse):
+    pass
+
+class UnLock500(UnLock50X):
+    code:int=Field(
+        500,
+        title='Response Status Code',
+        description='Protocol status code associated with response',
+        strict=True
+    )
+    message:str=Field(
+        'Unlocking Account Failed Due to an Internal Error',
+        title='Response Message',
+        description='Illustration meesage for the response state.',
+        strict=True
+    )

--- a/web-auth/views/unlock/response_dump.py
+++ b/web-auth/views/unlock/response_dump.py
@@ -1,0 +1,36 @@
+from .response_40x import UnLock400, UnLock404, UnLock409
+from .response_50x import UnLock500
+unlock_dump:dict={
+    400: {
+        'model': UnLock400,
+        'content': {
+            'application/json': {
+                'example': UnLock400().model_dump()
+            }
+        }
+    },
+    404: {
+        'model': UnLock404,
+        'content': {
+            'application/json': {
+                'example': UnLock404().model_dump()
+            }
+        }
+    },
+    409: {
+        'model': UnLock409,
+        'content': {
+            'application/json': {
+                'example': UnLock409().model_dump()
+            }
+        }
+    },
+    500: {
+        'model': UnLock500,
+        'content': {
+            'application/json': {
+                'example': UnLock500().model_dump()
+            }
+        }
+    },
+}


### PR DESCRIPTION
Implementing security measure to lock specific account when hitting rate-limit preventing brute force attacks.
***Adding two endpoints:***
1. Lock endpoint:
- When login attempts hit rate-limit.
- Accepts either [email] or [account_id].
2. Unlock endpoint:
- When user successfully unlock his account through automated restoration process.
- Accepts either [email] or [account_id].